### PR TITLE
Add overcurrent monitoring setup and test in ACS712

### DIFF
--- a/components/current_sensor/acs712_current_sensor.h
+++ b/components/current_sensor/acs712_current_sensor.h
@@ -6,13 +6,16 @@
 #include <stdbool.h>
 #include <esp_adc/adc_oneshot.h>
 #include <common_headers.h>
+#include <current_sensor_common.h>
 
 typedef error_type_t (*acs712_reading_callback_t)(void* context, int* adc_voltage);
 
+typedef error_type_t (*overcurrent_monitor_func_callback_t)(void* ads, const uint16_t high_threshold_value_in_millivolt, const uint16_t low_threshold_value_in_millivolt, overcurrent_comparator_callback_t comparator_callback, void* context);
 typedef struct{
     acs712_reading_callback_t adc_reader;
     void** context; // Context for the callback, can be used to pass additional data
     int zero_voltage; // Zero voltage offset for the sensor
+    overcurrent_monitor_func_callback_t overcurrent_monitor_func;   
 }acs712_config_t;
 
 
@@ -24,6 +27,7 @@ error_type_t acs712_sensor_init(acs712_sensor_t* sensor);
 error_type_t acs712_sensor_deinit(acs712_sensor_t* sensor);
 error_type_t acs712_destroy(acs712_sensor_t** sensor);
 error_type_t acs712_read_current(const acs712_sensor_t* sensor, float* current);
+error_type_t acs712_monitor_overcurrent(const acs712_sensor_t* sensor, float threshold_current, overcurrent_comparator_callback_t callback, void* context);
 
 
 #endif

--- a/components/current_sensor/ads1115.h
+++ b/components/current_sensor/ads1115.h
@@ -5,6 +5,7 @@
 #include "freertos/FreeRTOS.h"
 
 #include "common_headers.h"
+#include "current_sensor_common.h"
 typedef enum{
     ADS1115_CONVERSION_REGISTER,
     ADS1115_CONFIG_REGISTER,
@@ -85,15 +86,6 @@ typedef enum{
     ADD_SDA = 0x4B, // SDA address
 }ads1115_addr_t;
 
- typedef struct {
-    void* context;
-    TickType_t timestamp;
-    uint8_t channel;
-    void* callers_context;
- }overcurrent_queue_item_t;
-
-typedef void (*ads1115_comparator_callback_t)(overcurrent_queue_item_t item);
-
 typedef struct {
     i2c_port_t i2c_port; // I2C port number
     gpio_num_t sda_gpio; // SDA GPIO pin
@@ -114,8 +106,8 @@ error_type_t ads1115_init(ads1115_t* ads);
 error_type_t ads1115_set_read_channel(ads1115_t* ads, ads1115_input_channel_t input_channel);
 error_type_t ads1115_read_one_shot(const ads1115_t* ads, int16_t* raw_value);
 error_type_t ads1115_read_one_shot_with_channel(const ads1115_t* ads, int16_t* raw_value, ads1115_input_channel_t input_channel);
-error_type_t ads1115_read_comparator(ads1115_t* ads, const uint16_t high_threshold_value_in_millivolt, const uint16_t low_threshold_value_in_millivolt,ads1115_comparator_callback_t comparator_callback, void* context);
-error_type_t ads1115_read_comparator_with_channel(ads1115_t* ads, const uint16_t high_threshold_value_in_millivolt, const uint16_t low_threshold_value_in_millivolt,ads1115_comparator_callback_t comparator_callback, void* context, ads1115_input_channel_t input_channel);
+error_type_t ads1115_read_comparator(ads1115_t* ads, const uint16_t high_threshold_value_in_millivolt, const uint16_t low_threshold_value_in_millivolt, overcurrent_comparator_callback_t comparator_callback, void* context);
+error_type_t ads1115_read_comparator_with_channel(ads1115_t* ads, const uint16_t high_threshold_value_in_millivolt, const uint16_t low_threshold_value_in_millivolt, overcurrent_comparator_callback_t comparator_callback, void* context, ads1115_input_channel_t input_channel);
 error_type_t ads1115_deinit(ads1115_t* ads);
 error_type_t ads1115_destroy(ads1115_t** ads);
 

--- a/components/current_sensor/current_sensor_common.h
+++ b/components/current_sensor/current_sensor_common.h
@@ -1,0 +1,13 @@
+#ifndef __CURRENT_SENSOR_COMMON_H__
+#define __CURRENT_SENSOR_COMMON_H__
+#include <freertos/FreeRTOS.h>
+ typedef struct {
+    void* context;
+    TickType_t timestamp;
+    uint8_t channel;
+    void* callers_context;
+ }overcurrent_queue_item_t;
+
+typedef void (*overcurrent_comparator_callback_t)(overcurrent_queue_item_t item);
+
+#endif // __CURRENT_SENSOR_COMMON_H__

--- a/components/current_sensor/src/ads1115.c
+++ b/components/current_sensor/src/ads1115.c
@@ -23,8 +23,8 @@ struct ads1115_t {
     bool is_initialized; // Flag to check if the ADS1115 is initialized
     ads1115_input_channel_t input_channel;          // Current input channel for reading
     i2c_master_bus_handle_t i2c_handle; // I2C handle for communication
-     i2c_master_dev_handle_t i2c_dev_handle; // I2C device handle
-    ads1115_comparator_callback_t comparator_callback; // Callback for comparator alerts
+    i2c_master_dev_handle_t i2c_dev_handle; // I2C device handle
+    overcurrent_comparator_callback_t comparator_callback; // Callback for comparator alerts
     void* comparator_callback_context; // Context for comparator callback
 };
 
@@ -295,11 +295,11 @@ error_type_t get_threshold_buffer(const ads1115_t *ads, const uint16_t threshold
     return SYSTEM_OK;                            // Successfully prepared the threshold buffer
 }
 
-error_type_t ads1115_read_comparator(ads1115_t *ads, const uint16_t high_threshold_value_in_millivolt, const uint16_t low_threshold_value_in_millivolt, ads1115_comparator_callback_t comparator_callback, void* context){
+error_type_t ads1115_read_comparator(ads1115_t *ads, const uint16_t high_threshold_value_in_millivolt, const uint16_t low_threshold_value_in_millivolt, overcurrent_comparator_callback_t comparator_callback, void* context){
     return ads1115_read_comparator_with_channel(ads, high_threshold_value_in_millivolt, low_threshold_value_in_millivolt, comparator_callback, context, ads->input_channel);
 }
 
-error_type_t ads1115_read_comparator_with_channel(ads1115_t *ads, const uint16_t high_threshold_value_in_millivolt, const uint16_t low_threshold_value_in_millivolt, ads1115_comparator_callback_t comparator_callback, void* context,ads1115_input_channel_t input_channel)
+error_type_t ads1115_read_comparator_with_channel(ads1115_t *ads, const uint16_t high_threshold_value_in_millivolt, const uint16_t low_threshold_value_in_millivolt, overcurrent_comparator_callback_t comparator_callback, void* context,ads1115_input_channel_t input_channel)
 {
     if (ads == NULL)
     {


### PR DESCRIPTION
This PR does the following:

Allow the ACS712 current sensor to monitor overcurrent using callbacks
Add unit tests for overcurrent monitoring functionality