### PR TITLE
Add overcurrent monitoring functionality to current sensor component

### DIFF
--- a/components/current_sensor/acs712_current_sensor.h
+++ b/components/current_sensor/acs712_current_sensor.h
@@ -11,23 +11,31 @@
 typedef error_type_t (*acs712_reading_callback_t)(void* context, int* adc_voltage);
 
 typedef error_type_t (*overcurrent_monitor_func_callback_t)(void* ads, const uint16_t high_threshold_value_in_millivolt, const uint16_t low_threshold_value_in_millivolt, overcurrent_comparator_callback_t comparator_callback, void* context);
+
+typedef error_type_t (*acs712_measurement_complete_callback_t)(void* ads, measurement_complete_callback_t measurement_callback, void* context);
+
+typedef enum{
+    ACS712_READ_MODE_BASIC,
+    ACS712_READ_MODE_OVERCURRENT_MONITOR,
+    ACS712_READ_MODE_CONTINUOUS_MEASUREMENT
+} acs712_read_mode_t;
 typedef struct{
-    acs712_reading_callback_t adc_reader;
     void** context; // Context for the callback, can be used to pass additional data
     int zero_voltage; // Zero voltage offset for the sensor
-    overcurrent_monitor_func_callback_t overcurrent_monitor_func;   
+    void* callback_func; // Placeholder for future callback functions   
+    acs712_read_mode_t read_mode; // Reading mode of the sensor
+
 }acs712_config_t;
 
 
 typedef struct acs712_sensor_t acs712_sensor_t;
-
 
 acs712_sensor_t* acs712_create(acs712_config_t* config);
 error_type_t acs712_sensor_init(acs712_sensor_t* sensor);
 error_type_t acs712_sensor_deinit(acs712_sensor_t* sensor);
 error_type_t acs712_destroy(acs712_sensor_t** sensor);
 error_type_t acs712_read_current(const acs712_sensor_t* sensor, float* current);
-error_type_t acs712_monitor_overcurrent(const acs712_sensor_t* sensor, float threshold_current, overcurrent_comparator_callback_t callback, void* context);
-
+error_type_t acs712_monitor_current_window(const acs712_sensor_t* sensor, float max_threshold_current, float min_threshold_current, overcurrent_comparator_callback_t callback, void* context);
+error_type_t acs712_monitor_read_current_with_cb(const acs712_sensor_t* sensor, measurement_complete_callback_t callback, void* context);
 
 #endif

--- a/components/current_sensor/ads1115.h
+++ b/components/current_sensor/ads1115.h
@@ -86,6 +86,12 @@ typedef enum{
     ADD_SDA = 0x4B, // SDA address
 }ads1115_addr_t;
 
+typedef enum{
+    ADS1115_MEASUREMENT_ONE_SHOT = 0,
+    ADS1115_MEASUREMENT_CONTINUOUS_OVERCURRENT = 1,
+    ADS1115_MEASUREMENT_CONTINUOUS_READY = 2
+}ads1115_measurement_mode_t;
+
 typedef struct {
     i2c_port_t i2c_port; // I2C port number
     gpio_num_t sda_gpio; // SDA GPIO pin
@@ -97,6 +103,7 @@ typedef struct {
     uint32_t enable_pullup; // Enable pull-up resistors
     ads1115_addr_t i2c_address; // Address connection type
     ads1115_pga_mode_t pga_mode; // Programmable Gain Amplifier mode
+    ads1115_measurement_mode_t measurement_mode; // Measurement mode
 } ads1115_config_t;
 
 typedef struct ads1115_t ads1115_t;
@@ -108,6 +115,9 @@ error_type_t ads1115_read_one_shot(const ads1115_t* ads, int16_t* raw_value);
 error_type_t ads1115_read_one_shot_with_channel(const ads1115_t* ads, int16_t* raw_value, ads1115_input_channel_t input_channel);
 error_type_t ads1115_read_comparator(ads1115_t* ads, const uint16_t high_threshold_value_in_millivolt, const uint16_t low_threshold_value_in_millivolt, overcurrent_comparator_callback_t comparator_callback, void* context);
 error_type_t ads1115_read_comparator_with_channel(ads1115_t* ads, const uint16_t high_threshold_value_in_millivolt, const uint16_t low_threshold_value_in_millivolt, overcurrent_comparator_callback_t comparator_callback, void* context, ads1115_input_channel_t input_channel);
+error_type_t ads1115_read_continuous(ads1115_t* ads, measurement_complete_callback_t comparator_callback, void* context);
+error_type_t ads1115_read_continuous_with_channel(ads1115_t* ads, measurement_complete_callback_t measurement_callback, void* context,ads1115_input_channel_t input_channel);
+error_type_t ads1115_read_conversion_register(ads1115_t* ads, ads1115_input_channel_t input_channel, int16_t* raw_value);
 error_type_t ads1115_deinit(ads1115_t* ads);
 error_type_t ads1115_destroy(ads1115_t** ads);
 

--- a/components/current_sensor/current_sensor.h
+++ b/components/current_sensor/current_sensor.h
@@ -1,11 +1,11 @@
 #ifndef __CURRENT_SENSOR_H__
 #define __CURRENT_SENSOR_H__
 #include <common_headers.h>
-
+#include <current_sensor_common.h>
 
 typedef error_type_t (*current_sensor_reading_callback_t)(void* context, float* current_value);
 
- 
+typedef error_type_t (*current_sensor_overcurrent_monitor_callback_t)(void* sensor, float threshold_current, overcurrent_comparator_callback_t callback,  void* context);
 
 typedef struct{
     int id; // Unique identifier for the current sensor
@@ -13,6 +13,7 @@ typedef struct{
     current_sensor_reading_callback_t read_current; // Function pointer to read current
     char* make;
     int max_current;
+    current_sensor_overcurrent_monitor_callback_t overcurrent_callback; // Callback for overcurrent events
 }current_sensor_config_t;
 
 typedef struct current_sensor_t current_sensor_t;
@@ -22,5 +23,6 @@ error_type_t current_sensor_deinit(current_sensor_t *sensor);
 error_type_t current_sensor_destroy(current_sensor_t **sensor);
 error_type_t current_sensor_get_config(const current_sensor_t *sensor, current_sensor_config_t *config);
 error_type_t current_sensor_get_current_in_amp(const current_sensor_t *sensor, float *current);
+error_type_t current_sensor_monitor_overcurrent(const current_sensor_t* sensor, overcurrent_comparator_callback_t callback, void* context);
 
 #endif // __CURRENT_SENSOR_H__

--- a/components/current_sensor/current_sensor.h
+++ b/components/current_sensor/current_sensor.h
@@ -5,15 +5,24 @@
 
 typedef error_type_t (*current_sensor_reading_callback_t)(void* context, float* current_value);
 
-typedef error_type_t (*current_sensor_overcurrent_monitor_callback_t)(void* sensor, float threshold_current, overcurrent_comparator_callback_t callback,  void* context);
+typedef error_type_t (*current_sensor_overcurrent_monitor_callback_t)(void* sensor, float max_threshold_current, float min_threshold_current, overcurrent_comparator_callback_t callback,  void* context);
+
+typedef error_type_t (*current_sensor_continuous_read_callback_t)(void* sensor, measurement_complete_callback_t callback,  void* context);
+
+typedef enum{
+    CURRENT_SENSOR_READ_MODE_BASIC,
+    CURRENT_SENSOR_READ_MODE_OVERCURRENT_MONITOR,
+    CURRENT_SENSOR_READ_MODE_CONTINUOUS_MEASUREMENT
+} current_sensor_read_mode_t;
 
 typedef struct{
     int id; // Unique identifier for the current sensor
     void** context; // Context for the callback, can be used to pass additional data
-    current_sensor_reading_callback_t read_current; // Function pointer to read current
     char* make;
     int max_current;
-    current_sensor_overcurrent_monitor_callback_t overcurrent_callback; // Callback for overcurrent events
+    int min_current;
+    void* callback;
+    current_sensor_read_mode_t read_mode; // Reading mode of the sensor
 }current_sensor_config_t;
 
 typedef struct current_sensor_t current_sensor_t;
@@ -24,5 +33,6 @@ error_type_t current_sensor_destroy(current_sensor_t **sensor);
 error_type_t current_sensor_get_config(const current_sensor_t *sensor, current_sensor_config_t *config);
 error_type_t current_sensor_get_current_in_amp(const current_sensor_t *sensor, float *current);
 error_type_t current_sensor_monitor_overcurrent(const current_sensor_t* sensor, overcurrent_comparator_callback_t callback, void* context);
+error_type_t current_sensor_continuous_read(const current_sensor_t* sensor, measurement_complete_callback_t callback, void* context);
 
 #endif // __CURRENT_SENSOR_H__

--- a/components/current_sensor/current_sensor_common.h
+++ b/components/current_sensor/current_sensor_common.h
@@ -8,6 +8,14 @@
     void* callers_context;
  }overcurrent_queue_item_t;
 
+ typedef struct{
+      void* context;
+      uint8_t channel;
+ } measurement_item_t;
+
 typedef void (*overcurrent_comparator_callback_t)(overcurrent_queue_item_t item);
+
+typedef void(* measurement_complete_callback_t)(measurement_item_t item);
+
 
 #endif // __CURRENT_SENSOR_COMMON_H__

--- a/components/current_sensor/src/current_sensor.c
+++ b/components/current_sensor/src/current_sensor.c
@@ -8,7 +8,6 @@
 #include "esp_log.h"
 
 static const char* TAG = "CURRENT_SENSOR";
-static const float OVERCURRENT_THRESHOLD_PERCENTAGE = 0.8; // 80% of max current
 struct current_sensor_t {
     current_sensor_config_t* config; // Configuration for the current sensor
     bool is_initialized; // Flag to check if the sensor is initialized
@@ -33,7 +32,7 @@ error_type_t current_sensor_init(current_sensor_t *sensor) {
         return SYSTEM_INVALID_STATE; // Sensor is already initialized
     }
     // Validate the sensor configuration
-    if (sensor->config->id < 0 || sensor->config->read_current == NULL) {
+    if (sensor->config->id < 0 || sensor->config->callback == NULL) {
         return SYSTEM_INVALID_PARAMETER; // Handle invalid configuration
     }
     sensor->is_initialized = true; // Set the initialized flag
@@ -65,15 +64,24 @@ error_type_t current_sensor_destroy(current_sensor_t **sensor) {
 }
 
 error_type_t current_sensor_get_current_in_amp(const current_sensor_t *sensor, float *current_value) {
-    if (sensor == NULL || current_value == NULL) {
+    if (sensor == NULL || current_value == NULL || sensor->config == NULL) {
         return SYSTEM_NULL_PARAMETER; // Handle null sensor or reading pointer
     }
     if (!sensor->is_initialized) {
         return SYSTEM_INVALID_STATE; // Sensor is not initialized
     }
+    if(sensor->config->read_mode != CURRENT_SENSOR_READ_MODE_BASIC){
+        ESP_LOGE(TAG, "Sensor not in basic read mode");
+        return SYSTEM_INVALID_MODE;
+    }
     ESP_LOGI(TAG, "Getting current reading for sensor ID: %d", sensor->config->id);
+    current_sensor_reading_callback_t basic_read_cb = (current_sensor_reading_callback_t)sensor->config->callback;
+    if(!basic_read_cb){
+        ESP_LOGE(TAG, "Reading callback function not set");
+        return SYSTEM_NULL_PARAMETER;
+    }
     // Call the reading callback function to get the current value
-    error_type_t err = sensor->config->read_current(*sensor->config->context, current_value);
+    error_type_t err = basic_read_cb(*sensor->config->context, current_value);
     if (err != SYSTEM_OK) { 
         ESP_LOGE(TAG, "Error reading current: %d\n", err);
         return err; // Handle error in reading current
@@ -85,22 +93,57 @@ error_type_t current_sensor_get_current_in_amp(const current_sensor_t *sensor, f
 
 
 error_type_t current_sensor_monitor_overcurrent(const current_sensor_t* sensor, overcurrent_comparator_callback_t callback, void* context){
-    if (sensor == NULL) {
+    if (sensor == NULL || !sensor->config) {
         return SYSTEM_NULL_PARAMETER; // Handle null sensor
     }
     if (!sensor->is_initialized) {
         return SYSTEM_INVALID_STATE; // Sensor is not initialized
     }
-    if (callback == NULL) {
-        return SYSTEM_NULL_PARAMETER; // Handle null callback
+    if(sensor->config->read_mode != CURRENT_SENSOR_READ_MODE_OVERCURRENT_MONITOR){
+        ESP_LOGE(TAG, "Sensor not in overcurrent monitor mode");
+        return SYSTEM_INVALID_MODE;
     }
-    float threshold_current = sensor->config->max_current * OVERCURRENT_THRESHOLD_PERCENTAGE; 
-    ESP_LOGI(TAG, "Setting up overcurrent monitoring for sensor ID: %d with threshold: %.2f A", sensor->config->id, threshold_current);
+    float max_threshold_current = sensor->config->max_current; 
+    float min_threshold_current = sensor->config->min_current;
+    ESP_LOGI(TAG, "Setting up overcurrent monitoring for sensor ID: %d with threshold: %.2f A", sensor->config->id, max_threshold_current);
+    ESP_LOGI(TAG, "Setting up undercurrent monitoring for sensor ID: %d with threshold: %.2f A", sensor->config->id, min_threshold_current);
     // Call the overcurrent monitoring function from the sensor configuration
-    error_type_t err = sensor->config->overcurrent_callback(*sensor->config->context,threshold_current,callback, context);
+    current_sensor_overcurrent_monitor_callback_t overcurrent_monitor_cb = (current_sensor_overcurrent_monitor_callback_t)sensor->config->callback;
+    if(!overcurrent_monitor_cb){
+        ESP_LOGE(TAG, "Overcurrent monitoring callback function not set");
+        return SYSTEM_NULL_PARAMETER;
+    }
+    error_type_t err = overcurrent_monitor_cb(*sensor->config->context,max_threshold_current,min_threshold_current,callback, context);
     if (err != SYSTEM_OK) {
         ESP_LOGE(TAG, "Error setting up overcurrent monitoring: %d\n", err);
         return err; // Handle error in setting up overcurrent monitoring    
+    }
+    return SYSTEM_OK;
+}
+
+error_type_t current_sensor_continuous_read(const current_sensor_t* sensor, measurement_complete_callback_t callback, void* context)
+{
+    if (sensor == NULL || !sensor->config) {
+        return SYSTEM_NULL_PARAMETER; // Handle null sensor
+    }
+    if (!sensor->is_initialized) {
+        return SYSTEM_INVALID_STATE; // Sensor is not initialized
+    }
+    if(sensor->config->read_mode != CURRENT_SENSOR_READ_MODE_CONTINUOUS_MEASUREMENT){
+        ESP_LOGE(TAG, "Sensor not in continuous measurement mode");
+        return SYSTEM_INVALID_MODE;
+    }
+    ESP_LOGI(TAG, "Setting up continuous reading for sensor ID: %d", sensor->config->id);
+    // Call the continuous read function from the sensor configuration
+    current_sensor_continuous_read_callback_t continuous_read_cb = (current_sensor_continuous_read_callback_t)sensor->config->callback;
+    if(!continuous_read_cb){
+        ESP_LOGE(TAG, "Continuous read callback function not set");
+        return SYSTEM_NULL_PARAMETER;
+    }
+    error_type_t err = continuous_read_cb(*sensor->config->context, callback, context);
+    if (err != SYSTEM_OK) {
+        ESP_LOGE(TAG, "Error setting up continuous reading: %d\n", err);
+        return err; // Handle error in setting up continuous reading    
     }
     return SYSTEM_OK;
 }

--- a/components/current_sensor/test/CMakeLists.txt
+++ b/components/current_sensor/test/CMakeLists.txt
@@ -4,3 +4,5 @@ idf_component_register(SRC_DIRS "."
                        INCLUDE_DIRS "."
                        REQUIRES unity
                        PRIV_REQUIRES current_sensor common cmock)
+# uncomment the following line to enable hardware testing in this component's tests
+# target_compile_definitions(${COMPONENT_LIB} PRIVATE HARDWARE_TESTING_ENABLED=1)

--- a/components/current_sensor/test/test_acs712_current_sensor.c
+++ b/components/current_sensor/test/test_acs712_current_sensor.c
@@ -5,12 +5,25 @@
 
 #define ACS712_ZERO_VOLTAGE_DEFAULT 2500 // Default zero voltage for ACS712 converted from 5V to 3.3V range
 #define ACS712_SENSITIVITY 66 // ACS712 Sensitivity for ACS712 5
+
+typedef enum{
+    ACS712_TEST_CONFIG_ORDINARY,
+    ACS712_TEST_CONFIG_OVERCURRENT_MONITOR,
+    ACS712_TEST_CONFIG_CONTINUOUS_MEASUREMENT
+} acs712_test_config_type_t;
+
 acs712_sensor_t* acs712_sensor = NULL;
 const double OVERCURRENT_THRESHOLD_CURRENT = 10; // Example threshold current in Amperes
+const double UNDERCURRENT_THRESHOLD_CURRENT = 0; // Example threshold current in Amperes
 
  void overcurrent_comparator_callback (overcurrent_queue_item_t item){
     // Dummy callback function for overcurrent monitoring
     printf("Overcurrent event detected! Timestamp: %ld, Channel: %d\n", item.timestamp, item.channel);
+ }
+
+ void measurement_complete_callback_func (measurement_item_t item){
+    // Dummy callback function for measurement complete
+    printf("Measurement complete event detected! Channel: %d\n", item.channel);
  }
 
 error_type_t overcurrent_monitor_func_callback (void* ads, const uint16_t high_threshold_value_in_millivolt, const uint16_t low_threshold_value_in_millivolt, overcurrent_comparator_callback_t comparator_callback, void* context)
@@ -20,6 +33,10 @@ error_type_t overcurrent_monitor_func_callback (void* ads, const uint16_t high_t
     printf("Setting up overcurrent monitoring with high threshold: %d mV, low threshold: %d mV\n", high_threshold_value_in_millivolt, low_threshold_value_in_millivolt);
     TEST_ASSERT_EQUAL(high_threshold_value_in_millivolt, 3160); // Example expected high threshold
     TEST_ASSERT_EQUAL(low_threshold_value_in_millivolt, 1840); // Example expected low threshold
+    return SYSTEM_OK;
+}
+
+error_type_t measurement_complete_monitor_func_callback (void* ads, measurement_complete_callback_t measurement_callback, void* context){
     return SYSTEM_OK;
 }
 
@@ -33,17 +50,45 @@ error_type_t get_adc_value(void* context, int* adc_voltage) {
 // dunmmy void context for the ADC reader callback
 int dummy_value = 1;
 void* dummy_context = &dummy_value;
-acs712_config_t acs712_config = {
-    .adc_reader = get_adc_value,
+
+acs712_config_t acs712_config_ordinary = {
     .context = &dummy_context, // Context for the callback, can be used to pass additional data
     .zero_voltage = 2500, // Zero voltage offset for the sensor
-    .overcurrent_monitor_func = overcurrent_monitor_func_callback
+    .callback_func = (void*)get_adc_value,
+    .read_mode = ACS712_READ_MODE_BASIC
 }; // Initialize with a NULL ADC reader
-// Set up function for ACS712 sensor tests
-void acs712SensorSetUp(void) {
-    // Set up code before each test
 
-    acs712_sensor = acs712_create(&acs712_config);
+acs712_config_t acs712_config_overcurrent_monitor = {
+    .context = &dummy_context, // Context for the callback, can be used to pass additional data
+    .zero_voltage = 2500, // Zero voltage offset for the sensor
+    .callback_func = (void*)overcurrent_monitor_func_callback,
+    .read_mode = ACS712_READ_MODE_OVERCURRENT_MONITOR
+}; // Initialize with a NULL ADC reader
+
+acs712_config_t acs712_config_continuous_measurement = {
+    .context = &dummy_context, // Context for the callback, can be used to pass additional data
+    .zero_voltage = 2500, // Zero voltage offset for the sensor
+    .callback_func = (void*)measurement_complete_monitor_func_callback,
+    .read_mode = ACS712_READ_MODE_CONTINUOUS_MEASUREMENT
+}; // Initialize with a NULL ADC reader
+
+// Set up function for ACS712 sensor tests
+void acs712SensorSetUp(acs712_test_config_type_t config_type) {
+    // Set up code before each test
+    switch(config_type){
+        case ACS712_TEST_CONFIG_ORDINARY:
+            acs712_sensor = acs712_create(&acs712_config_ordinary);
+            break;
+        case ACS712_TEST_CONFIG_OVERCURRENT_MONITOR:
+            acs712_sensor = acs712_create(&acs712_config_overcurrent_monitor);
+            break;
+        case ACS712_TEST_CONFIG_CONTINUOUS_MEASUREMENT:
+            acs712_sensor = acs712_create(&acs712_config_continuous_measurement);
+            break;
+        default:
+            acs712_sensor = acs712_create(&acs712_config_ordinary);
+            break;
+    }
 }
 
 void acs712SensorTearDown(void) {
@@ -56,20 +101,20 @@ void acs712SensorTearDown(void) {
 
 
 TEST_CASE("acs712_current_sensor_test", "test_acs712_create") {
-    acs712SensorSetUp();
+    acs712SensorSetUp(ACS712_TEST_CONFIG_ORDINARY);
     TEST_ASSERT_NOT_NULL(acs712_sensor);
     acs712SensorTearDown();
 }
 
 TEST_CASE("acs712_current_sensor_test", "test_acs712_init") {
-    acs712SensorSetUp();
+    acs712SensorSetUp(ACS712_TEST_CONFIG_ORDINARY);
     error_type_t result = acs712_sensor_init(acs712_sensor);
     TEST_ASSERT_EQUAL(SYSTEM_OK, result);
     acs712SensorTearDown();
 }
 
 TEST_CASE("acs712_current_sensor_test", "test_acs712_deinit") {
-    acs712SensorSetUp();
+    acs712SensorSetUp(ACS712_TEST_CONFIG_ORDINARY);
     error_type_t result = acs712_sensor_init(acs712_sensor);
     TEST_ASSERT_EQUAL(SYSTEM_OK, result);
     result = acs712_sensor_deinit(acs712_sensor);
@@ -78,7 +123,7 @@ TEST_CASE("acs712_current_sensor_test", "test_acs712_deinit") {
 }
 
 TEST_CASE("acs712_current_sensor_test", "test_acs712_destroy") {
-    acs712SensorSetUp();
+    acs712SensorSetUp(ACS712_TEST_CONFIG_ORDINARY);
     error_type_t result = acs712_sensor_init(acs712_sensor);
     TEST_ASSERT_EQUAL(SYSTEM_OK, result);
     result = acs712_destroy(&acs712_sensor);
@@ -87,7 +132,7 @@ TEST_CASE("acs712_current_sensor_test", "test_acs712_destroy") {
 }
 
 TEST_CASE("acs712_current_sensor_test", "test_acs712_read_current") {
-    acs712SensorSetUp();
+    acs712SensorSetUp(ACS712_TEST_CONFIG_ORDINARY);
     error_type_t result = acs712_sensor_init(acs712_sensor);
     TEST_ASSERT_EQUAL(SYSTEM_OK, result);
 
@@ -102,10 +147,20 @@ TEST_CASE("acs712_current_sensor_test", "test_acs712_read_current") {
 
 
 TEST_CASE("acs712_current_sensor_test", "test_acs712_overcurrent_monitor") {
-    acs712SensorSetUp();
+    acs712SensorSetUp(ACS712_TEST_CONFIG_OVERCURRENT_MONITOR);
     error_type_t result = acs712_sensor_init(acs712_sensor);
     TEST_ASSERT_EQUAL(SYSTEM_OK, result);
-    result = acs712_monitor_overcurrent(acs712_sensor, OVERCURRENT_THRESHOLD_CURRENT , overcurrent_comparator_callback, NULL);
+    result = acs712_monitor_current_window(acs712_sensor, OVERCURRENT_THRESHOLD_CURRENT,UNDERCURRENT_THRESHOLD_CURRENT, overcurrent_comparator_callback, NULL);
+    TEST_ASSERT_EQUAL(SYSTEM_OK, result);
+    acs712SensorTearDown();
+}
+
+
+TEST_CASE("acs712_current_sensor_test", "test_acs712_continuous_measurement") {
+    acs712SensorSetUp(ACS712_TEST_CONFIG_CONTINUOUS_MEASUREMENT);
+    error_type_t result = acs712_sensor_init(acs712_sensor);
+    TEST_ASSERT_EQUAL(SYSTEM_OK, result);
+    result = acs712_monitor_read_current_with_cb(acs712_sensor, measurement_complete_callback_func, NULL);
     TEST_ASSERT_EQUAL(SYSTEM_OK, result);
     acs712SensorTearDown();
 }

--- a/components/current_sensor/test/test_current_sensor.c
+++ b/components/current_sensor/test/test_current_sensor.c
@@ -14,6 +14,15 @@ error_type_t dummy_read_current(void* context, float* current_value) {
     return SYSTEM_OK; // Simulate successful read
 }
 
+error_type_t current_sensor_overcurrent_monitor_func_callback(void* sensor, float threshold_current, overcurrent_comparator_callback_t callback, void* context){
+    // Dummy function to simulate setting up overcurrent monitoring
+    // In a real scenario, this would configure the sensor's comparator functionality
+    ESP_LOGI(TAG, "Overcurrent monitoring set with threshold: %f", threshold_current);
+    // using 16.0f as expected threshold because max_current is 20 and 80% of 20 is 16.0
+    TEST_ASSERT_EQUAL_FLOAT(threshold_current, 16.0f); // Example expected threshold
+    return SYSTEM_OK; // Simulate successful setup
+}
+
 // dummy void context for the current sensor callback
 int current_sensor_dummy_value = 1;
 void* current_sensor_dummy_context = NULL;
@@ -21,6 +30,9 @@ current_sensor_config_t current_sensor_config = {
     .id = 1,
     .context = &current_sensor_dummy_context, // Context for the callback, can be used to pass additional data
     .read_current = dummy_read_current, // Assuming a function pointer to read current is set later
+    .make = "DummySensor",
+    .max_current = 20,
+    .overcurrent_callback = current_sensor_overcurrent_monitor_func_callback
 };
 void currentSensorSetUp(void) {
     // Set up code before each test
@@ -76,5 +88,20 @@ TEST_CASE("current_sensor_test", "test_current_sensor_get_reading") {
     TEST_ASSERT_EQUAL(SYSTEM_OK, result);
     ESP_LOGI(TAG,"Current reading: %f", current_value);
     TEST_ASSERT_EQUAL_FLOAT(current_value, 10.0f); // Check if the reading matches the dummy value
+    currentSensorTearDown();
+}
+static void overcurrent_callback(overcurrent_queue_item_t item) {
+    ESP_LOGI(TAG, "Overcurrent event detected!");
+}
+TEST_CASE("current_sensor_test", "test_current_sensor_monitor_overcurrent") {
+    currentSensorSetUp();
+    error_type_t result = current_sensor_init(current_sensor);
+    TEST_ASSERT_EQUAL(SYSTEM_OK, result);
+
+    // Dummy callback function for overcurrent event
+
+    result = current_sensor_monitor_overcurrent(current_sensor, overcurrent_callback, (void*)&current_sensor_dummy_value);
+    TEST_ASSERT_EQUAL(SYSTEM_OK, result);
+
     currentSensorTearDown();
 }

--- a/components/current_sensor/test/test_current_sensor.c
+++ b/components/current_sensor/test/test_current_sensor.c
@@ -7,6 +7,12 @@
 current_sensor_t* current_sensor = NULL;
 static const char* TAG = "CURRENT_SENSOR";
 
+typedef enum {
+    CURRENT_SENSOR_TEST_CONFIG_BASIC_READING = 0,
+    CURRENT_SENSOR_TEST_CONFIG_OVERCURRENT_MONITORING = 1,
+    CURRENT_SENSOR_TEST_CONFIG_CONTINUOUS_MEASUREMENT = 2
+} current_sensor_test_config_type_t;
+
 error_type_t dummy_read_current(void* context, float* current_value) {
     // Dummy function to simulate reading current
     // In a real scenario, this would read from the actual sensor hardware
@@ -14,30 +20,74 @@ error_type_t dummy_read_current(void* context, float* current_value) {
     return SYSTEM_OK; // Simulate successful read
 }
 
-error_type_t current_sensor_overcurrent_monitor_func_callback(void* sensor, float threshold_current, overcurrent_comparator_callback_t callback, void* context){
+error_type_t current_sensor_overcurrent_monitor_func_callback(void* sensor, float max_threshold_current, float min_threshold_current, overcurrent_comparator_callback_t callback, void* context){
     // Dummy function to simulate setting up overcurrent monitoring
     // In a real scenario, this would configure the sensor's comparator functionality
-    ESP_LOGI(TAG, "Overcurrent monitoring set with threshold: %f", threshold_current);
-    // using 16.0f as expected threshold because max_current is 20 and 80% of 20 is 16.0
-    TEST_ASSERT_EQUAL_FLOAT(threshold_current, 16.0f); // Example expected threshold
+    ESP_LOGI(TAG, "Overcurrent monitoring set with threshold: %f", max_threshold_current);
+    ESP_LOGI(TAG, "Undercurrent monitoring set with threshold: %f", min_threshold_current);
+    TEST_ASSERT_EQUAL_FLOAT(max_threshold_current, 20.0f); // Example expected threshold
+    return SYSTEM_OK; // Simulate successful setup
+}
+
+error_type_t current_sensor_continuous_read_func_callback(void* sensor,measurement_complete_callback_t callback, void* context){
+    // Dummy function to simulate setting up overcurrent monitoring
+    // In a real scenario, this would configure the sensor's comparator functionality
     return SYSTEM_OK; // Simulate successful setup
 }
 
 // dummy void context for the current sensor callback
 int current_sensor_dummy_value = 1;
 void* current_sensor_dummy_context = NULL;
-current_sensor_config_t current_sensor_config = {
+current_sensor_config_t current_sensor_config_basic = {
     .id = 1,
     .context = &current_sensor_dummy_context, // Context for the callback, can be used to pass additional data
-    .read_current = dummy_read_current, // Assuming a function pointer to read current is set later
     .make = "DummySensor",
     .max_current = 20,
-    .overcurrent_callback = current_sensor_overcurrent_monitor_func_callback
+    .min_current = 0,
+    .callback = (void*)dummy_read_current, // Assuming a function pointer to read current is set later
+    .read_mode = CURRENT_SENSOR_READ_MODE_BASIC
 };
-void currentSensorSetUp(void) {
-    // Set up code before each test
+current_sensor_config_t current_sensor_config_overcurrent = {
+    .id = 1,
+    .context = &current_sensor_dummy_context, // Context for the callback, can be used to pass additional data
+    .make = "DummySensor",
+    .max_current = 20,
+    .min_current = 0,
+    .callback = (void*)current_sensor_overcurrent_monitor_func_callback, // Assuming a function pointer to read current is set later
+    .read_mode = CURRENT_SENSOR_READ_MODE_OVERCURRENT_MONITOR
+};
 
-    current_sensor = current_sensor_create(&current_sensor_config);
+current_sensor_config_t current_sensor_config_continuous = {
+    .id = 1,
+    .context = &current_sensor_dummy_context, // Context for the callback, can be used to pass additional data
+    .make = "DummySensor",
+    .max_current = 20,
+    .min_current = 0,
+    .callback = (void*)current_sensor_continuous_read_func_callback, // Assuming a function pointer to read current is set later
+    .read_mode = CURRENT_SENSOR_READ_MODE_CONTINUOUS_MEASUREMENT
+};
+
+
+void currentSensorSetUp(current_sensor_test_config_type_t current_sensor_test_config_type) {
+    // Set up code before each test
+    switch (current_sensor_test_config_type){
+        case CURRENT_SENSOR_TEST_CONFIG_BASIC_READING:
+            // Set up for basic reading tests
+            current_sensor = current_sensor_create(&current_sensor_config_basic);
+            break;
+        case CURRENT_SENSOR_TEST_CONFIG_OVERCURRENT_MONITORING:
+            // Set up for overcurrent monitoring tests
+            current_sensor = current_sensor_create(&current_sensor_config_overcurrent);
+            break;
+        case CURRENT_SENSOR_TEST_CONFIG_CONTINUOUS_MEASUREMENT:
+            // Set up for continuous measurement tests
+            current_sensor = current_sensor_create(&current_sensor_config_continuous);
+            break;
+        default:
+            // Default setup
+            current_sensor = current_sensor_create(&current_sensor_config_basic);
+            break;
+    }
 }
 
 void currentSensorTearDown(void) {
@@ -48,20 +98,20 @@ void currentSensorTearDown(void) {
 }
 
 TEST_CASE("current_sensor_test", "test_current_sensor_create") {
-    currentSensorSetUp();
+    currentSensorSetUp(CURRENT_SENSOR_TEST_CONFIG_BASIC_READING);
     TEST_ASSERT_NOT_NULL(current_sensor);
     currentSensorTearDown();
 }
 
 TEST_CASE("current_sensor_test", "test_current_sensor_init") {
-    currentSensorSetUp();
+    currentSensorSetUp(CURRENT_SENSOR_TEST_CONFIG_BASIC_READING);
     error_type_t result = current_sensor_init(current_sensor);
     TEST_ASSERT_EQUAL(SYSTEM_OK, result);
     currentSensorTearDown();
 }
 
 TEST_CASE("current_sensor_test", "test_current_sensor_deinit") {
-    currentSensorSetUp();
+    currentSensorSetUp(CURRENT_SENSOR_TEST_CONFIG_BASIC_READING);
     error_type_t result = current_sensor_init(current_sensor);
     TEST_ASSERT_EQUAL(SYSTEM_OK, result);
     result = current_sensor_deinit(current_sensor);
@@ -70,7 +120,7 @@ TEST_CASE("current_sensor_test", "test_current_sensor_deinit") {
 }
 
 TEST_CASE("current_sensor_test", "test_current_sensor_destroy") {
-    currentSensorSetUp();
+    currentSensorSetUp(CURRENT_SENSOR_TEST_CONFIG_BASIC_READING);
     error_type_t result = current_sensor_init(current_sensor);
     TEST_ASSERT_EQUAL(SYSTEM_OK, result);
     result = current_sensor_destroy(&current_sensor);
@@ -79,7 +129,7 @@ TEST_CASE("current_sensor_test", "test_current_sensor_destroy") {
 }
 
 TEST_CASE("current_sensor_test", "test_current_sensor_get_reading") {
-    currentSensorSetUp();
+    currentSensorSetUp(CURRENT_SENSOR_TEST_CONFIG_BASIC_READING);
     error_type_t result = current_sensor_init(current_sensor);
     TEST_ASSERT_EQUAL(SYSTEM_OK, result);
 
@@ -94,13 +144,30 @@ static void overcurrent_callback(overcurrent_queue_item_t item) {
     ESP_LOGI(TAG, "Overcurrent event detected!");
 }
 TEST_CASE("current_sensor_test", "test_current_sensor_monitor_overcurrent") {
-    currentSensorSetUp();
+    currentSensorSetUp(CURRENT_SENSOR_TEST_CONFIG_OVERCURRENT_MONITORING);
     error_type_t result = current_sensor_init(current_sensor);
     TEST_ASSERT_EQUAL(SYSTEM_OK, result);
 
     // Dummy callback function for overcurrent event
 
     result = current_sensor_monitor_overcurrent(current_sensor, overcurrent_callback, (void*)&current_sensor_dummy_value);
+    TEST_ASSERT_EQUAL(SYSTEM_OK, result);
+
+    currentSensorTearDown();
+}
+
+static void continuous_read_callback(measurement_item_t item) {
+    ESP_LOGI(TAG, "continuous read event detected!");
+}
+
+TEST_CASE("current_sensor_test", "test_current_sensor_continuous_read") {
+    currentSensorSetUp(CURRENT_SENSOR_TEST_CONFIG_CONTINUOUS_MEASUREMENT);
+    error_type_t result = current_sensor_init(current_sensor);
+    TEST_ASSERT_EQUAL(SYSTEM_OK, result);
+
+    // Dummy callback function for overcurrent event
+
+    result = current_sensor_continuous_read(current_sensor, continuous_read_callback, (void*)&current_sensor_dummy_value);
     TEST_ASSERT_EQUAL(SYSTEM_OK, result);
 
     currentSensorTearDown();

--- a/components/pump_monitor_task/src/pump_monitor_task.c
+++ b/components/pump_monitor_task/src/pump_monitor_task.c
@@ -135,7 +135,7 @@ static void pump_monitor_task(void *pvParameters)
         return;
     }
 
-    acs_config.adc_reader = adc_reader_cb;
+    acs_config.callback_func = adc_reader_cb;
     acs_config.context = (void**)&objects.context;
     objects.acs = acs712_create(&acs_config);
     if (objects.acs == NULL || acs712_sensor_init(objects.acs) != SYSTEM_OK)
@@ -158,7 +158,7 @@ static void pump_monitor_task(void *pvParameters)
     current_sensor_config_t cs_config = {
         .id = cs_id,
         .context = (void **)&objects.acs, // Cast to void** here as well
-        .read_current = current_sensor_ac712_read_callback
+        .callback = (void*)current_sensor_ac712_read_callback
     };
     objects.cs = current_sensor_create(&cs_config);
     if (objects.cs == NULL || current_sensor_init(objects.cs) != SYSTEM_OK)


### PR DESCRIPTION
This PR

Allows current sensor to monitor overcurrent conditions by registering a callback function that gets invoked when the current exceeds the defined threshold.